### PR TITLE
Fix permission page not showing if service disabled but all permissions granted

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,19 @@ dependencies:
   permission_handler: ^10.2.0
 ```
 2. This package depends on [permission_handler](https://pub.dev/packages/permission_handler). Perform setup according to that package.
-3. If any features is required, it is highly recommended to also set the `<uses-feature>` tag in AndroidManifest.xml. Refer to [relevant Android Developers page](https://developer.android.com/guide/topics/manifest/uses-feature-element) for details. 
+3. On Android, if you use `POST_NOTIFICATIONS` permission, update the `targetSdkVersion` in `build.gradle` to at least 33 so that the permission request dialog is shown correctly. Refer to [relevant Android Developer page](https://developer.android.com/develop/ui/views/notifications/notification-permission) for details.
+```groovy
+android {
+    // ...
+    defaultConfig {
+        compileSdkVersion 33
+        targetSdkVersion 33
+        // ...
+    }
+    // ...
+}
+```
+4. If any features is required, it is highly recommended to also set the `<uses-feature>` tag in AndroidManifest.xml. Refer to [relevant Android Developers page](https://developer.android.com/guide/topics/manifest/uses-feature-element) for details. 
 
 ## Usage
 1. Create an instance of FlutterForcePermission, providing configuration.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ android {
 4. If any features is required, it is highly recommended to also set the `<uses-feature>` tag in AndroidManifest.xml. Refer to [relevant Android Developers page](https://developer.android.com/guide/topics/manifest/uses-feature-element) for details. 
 
 ## Usage
-1. Create an instance of FlutterForcePermission, providing configuration.
+1. Create an instance of FlutterForcePermission, providing configuration. Refer to documentation for [FlutterForcePermissionConfig] for details.
 ```dart
 final perm = FlutterForcePermission(
     FlutterForcePermissionConfig(

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -59,6 +59,12 @@ class FlutterForcePermission {
           needShow = true;
           break;
         }
+        if (perm is PermissionWithService &&
+            permissionStatuses[perm]?.serviceStatus == ServiceStatus.disabled &&
+            permConfig.required) {
+          needShow = true;
+          break;
+        }
       }
     }
 

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -23,7 +23,7 @@ class FlutterForcePermission {
 
   final TestStub _service;
 
-  var bool _showing;
+  bool _showing = false;
 
   /// Show disclosure page.
   ///

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -23,9 +23,12 @@ class FlutterForcePermission {
 
   final TestStub _service;
 
+  var bool _showing;
+
   /// Show disclosure page.
   ///
   /// This will show the disclosure page according to the provided configuration, and handles requesting permissions.
+  /// If the disclosure page is already shown, it will do nothing.
   /// Returns a map of Permission and their status after requesting the permissions.
   /// Only permissions specified in the configuration will be included in the return value.
   Future<Map<Permission, PermissionServiceStatus>> show(
@@ -33,6 +36,8 @@ class FlutterForcePermission {
   ) async {
     // Check for permissions.
     final permissionStatuses = await getPermissionStatuses();
+    if (_showing) return permissionStatuses;
+    _showing = true;
 
     if (permissionStatuses.values
         .every((element) => element.status == PermissionStatus.granted)) {
@@ -71,6 +76,8 @@ class FlutterForcePermission {
         ),
       ),
     );
+
+    _showing = false;
 
     // Check for permission status again as it is likely updated.
     return getPermissionStatuses();

--- a/lib/permission_item_config.dart
+++ b/lib/permission_item_config.dart
@@ -21,16 +21,19 @@ class PermissionItemConfig {
   /// The display item configuration for these permission(s). Refer to [PermissionItemText] for details.
   final PermissionItemText itemText;
 
-  /// If the permission has an associated service (e.g. location), this service
-  /// will also be checked for availability.
+  /// If the permission has an associated service (e.g. location) and this permission is required,
+  /// this service will also be checked for availability.
   /// If service is unavailable and this item is not null, the disclosure page will
   /// show a disclosure item for this service, before `itemText`.
-  /// If this permission is required, users will also be asked to enable the service.
+  /// Users will also be asked to enable the service.
+  ///
+  /// *Note*: This is used only when `required` is true.
   final PermissionItemText? serviceItemText;
 
   /// Whether these permission(s) are required.
   ///
-  /// If it is required, users cannot migrate out of disclosure page until the permission is granted. `forcedPermissionDialogConfig` should include configuration for the
+  /// If it is required, users cannot migrate out of disclosure page until the permission is granted.
+  /// `forcedPermissionDialogConfig` under `itemText` should include configuration for the
   /// dialog shown when required permission are denied.
   final bool required;
 }

--- a/lib/permission_item_text.dart
+++ b/lib/permission_item_text.dart
@@ -16,7 +16,7 @@ class PermissionItemText {
   /// The Icon for the permission item.
   ///
   /// If omitted, a default icon will be provided.
-  final Icon? icon;
+  final Widget? icon;
 
   /// Detailed text for the permission.
   ///

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -109,10 +109,17 @@ class _DisclosurePageState extends State<DisclosurePage>
 
     final permissionItems =
         widget.permissionConfig.permissionItemConfigs.expand((e) {
-      final denied = widget.permissionStatuses.values
-          .any((element) => element.status != PermissionStatus.granted);
-      final serviceDisabled = widget.permissionStatuses.values
-          .any((element) => element.serviceStatus == ServiceStatus.disabled);
+      var denied = false;
+      var serviceDisabled = false;
+      for (final Permission p in e.permissions) {
+        if (widget.permissionStatuses[p]?.status != PermissionStatus.granted) {
+          denied = true;
+        }
+        if (widget.permissionStatuses[p]?.serviceStatus ==
+            ServiceStatus.disabled) {
+          serviceDisabled = true;
+        }
+      }
       final itemText = e.itemText;
       final serviceText = e.serviceItemText;
       final permission = e.permissions.first;


### PR DESCRIPTION
#### What does this change?
Fix permission page not showing if service disabled but all permissions granted. Includes changes in #4

#### How do we test this change?
1. Config with location and it's service being required
2. Grant location permission
3. Disable GPS
4. Call `show` again. Page does not show without GPS

#### Checklist
- [x] Run the `pre_pr.sh` script to ensure code quality.