### PR TITLE
add requested state to permissionStatus, fix requested bg location show up

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,11 @@
 Describe your changes.
 
 #### How do we test this change?
-- [ ] Describe how we can test this change.
+1. Describe how we can test this change.
 
 #### Any screenshot for this change?
 Post any screenshots for your feature, if any.
 
 #### Checklist
+- [ ] Create suitable unit/widget tests for your change.
 - [ ] Run the `pre_pr.sh` script to ensure code quality.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ final perm = FlutterForcePermission(
 2. Show the disclosure page as needed. This method will handle showing the disclosure page and requesting permissions.
 This function takes a [NavigatorState](https://api.flutter.dev/flutter/widgets/NavigatorState-class.html) which can be retrieved through `Navigator.of(context)` call.
 This is an async function. Wrap the function in an `async` block as needed.
-Returns a map of permission and their requested status (granted/denied/etc). Refer to [permission_handler](https://pub.dev/packages/permission_handler) for the interface.
+Returns a map of permission and their requested status (granted/denied/etc), service status and whether they are requested by this plugin.
 ```dart
 final result = await perm.show(Navigator.of(context));
 ```

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Show permission disclosure page and allows required permissions and their associ
 This package shows a prominent in-app disclosure page for getting permissions as required by [Google Play](https://support.google.com/googleplay/android-developer/answer/9799150?visit_id=638041800350153935-369621111&p=pd-m&rd=1#prominent_disclosure&zippy=%2Cstep-provide-prominent-in-app-disclosure%2Cstep-review-best-practices-for-accessing-location%2Cstep-consider-alternatives-to-accessing-location-in-the-background%2Cstep-make-access-to-location-in-the-background-clear-to-users%2Csee-an-example-of-prominent-in-app-disclosure).
 Also support iOS to ensure a consistent experience.
 
-In addition, permissions can be set as "required". If this is set, those required permissions will be required and if users denied it, 
-this package will show a custom dialog and redirect user to the appropriate settings page provided by the OS.
+In addition, permissions and their associated services (e.g. GPS) can be set as "required". If this is set, those required permissions will 
+be required and if users denied it, this package will show a customizable dialog and redirect user to the appropriate settings page provided by the native OS.
 
 ## Setup
 1. Add the following to `pubspec.yaml`

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -45,12 +45,10 @@ class FlutterForcePermission {
       return permissionStatuses;
     }
 
-    final prefs = await _service.getSharedPreference();
     var needShow = false;
     for (final permConfig in config.permissionItemConfigs) {
       for (final perm in permConfig.permissions) {
-        final requested = prefs.getBool(getRequestedPrefKey(perm));
-        if (requested != true) {
+        if (!(permissionStatuses[perm]?.requested ?? true)) {
           needShow = true;
           break;
         }
@@ -94,17 +92,20 @@ class FlutterForcePermission {
   /// Only permissions specified in the configuration will be queried and returned.
   Future<Map<Permission, PermissionServiceStatus>>
       getPermissionStatuses() async {
+    final prefs = await _service.getSharedPreference();
     final Map<Permission, PermissionServiceStatus> result = {};
     for (final List<Permission> perms
         in config.permissionItemConfigs.map((e) => e.permissions)) {
       for (final Permission perm in perms) {
         final status = await _service.status(perm);
+        final requested = prefs.getBool(getRequestedPrefKey(perm)) ?? false;
         ServiceStatus? serviceStatus;
         if (perm is PermissionWithService) {
           serviceStatus = await _service.serviceStatus(perm);
         }
         result[perm] = PermissionServiceStatus(
           status: status,
+          requested: requested,
           serviceStatus: serviceStatus,
         );
       }

--- a/lib/permission_service_status.dart
+++ b/lib/permission_service_status.dart
@@ -4,16 +4,23 @@ import 'package:permission_handler/permission_handler.dart';
 class PermissionServiceStatus {
   PermissionServiceStatus({
     required this.status,
+    required this.requested,
     this.serviceStatus,
   });
 
   /// Status of the permission.
   final PermissionStatus status;
 
+  /// Whether the permission is requested by this plugin.
+  ///
+  /// Note that detecting whether a permission is requested by anywhere from the app is not possible due to
+  /// a lack of an API to query such information without actually making the request in both Android and iOS.
+  final bool requested;
+
   /// Status of the service associated to the permission. Null if no associated service.
   final ServiceStatus? serviceStatus;
 
   @override
   String toString() =>
-      'PermissionServiceStatus{status: $status, serviceStatus: $serviceStatus}';
+      'PermissionServiceStatus{status: $status, requested: $requested, serviceStatus: $serviceStatus}';
 }

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -110,10 +110,14 @@ class _DisclosurePageState extends State<DisclosurePage>
     final permissionItems =
         widget.permissionConfig.permissionItemConfigs.expand((e) {
       var denied = false;
+      var requested = false;
       var serviceDisabled = false;
       for (final Permission p in e.permissions) {
         if (widget.permissionStatuses[p]?.status != PermissionStatus.granted) {
           denied = true;
+        }
+        if (widget.permissionStatuses[p]?.requested ?? true) {
+          requested = true;
         }
         if (widget.permissionStatuses[p]?.serviceStatus ==
             ServiceStatus.disabled) {
@@ -128,7 +132,7 @@ class _DisclosurePageState extends State<DisclosurePage>
       if (serviceDisabled && serviceText != null) {
         result.add(_PermissionItem(permission, serviceText));
       }
-      if (denied) {
+      if (denied && !requested) {
         result.add(_PermissionItem(permission, itemText));
       }
 

--- a/test/widget_test/disclosure_page_test.dart
+++ b/test/widget_test/disclosure_page_test.dart
@@ -49,6 +49,7 @@ void main() {
     final status = <Permission, PermissionServiceStatus>{
       Permission.location: PermissionServiceStatus(
         status: PermissionStatus.denied,
+        requested: false,
         serviceStatus: ServiceStatus.enabled,
       ),
     };
@@ -111,6 +112,7 @@ void main() {
     final status = <Permission, PermissionServiceStatus>{
       Permission.location: PermissionServiceStatus(
         status: PermissionStatus.denied,
+        requested: false,
         serviceStatus: ServiceStatus.enabled,
       ),
     };
@@ -175,6 +177,7 @@ void main() {
     final status = <Permission, PermissionServiceStatus>{
       Permission.location: PermissionServiceStatus(
         status: PermissionStatus.denied,
+        requested: false,
         serviceStatus: ServiceStatus.enabled,
       ),
     };
@@ -269,6 +272,7 @@ void main() {
     final status = <Permission, PermissionServiceStatus>{
       Permission.location: PermissionServiceStatus(
         status: PermissionStatus.granted,
+        requested: false,
         serviceStatus: ServiceStatus.disabled,
       ),
     };


### PR DESCRIPTION
#### What does this change?
Add requested state to `permissionStatus` to fix already-requested permissions to show when the service of it is disabled.

#### How do we test this change?
1. Make Foreground location and GPS required, Background location optional
2. Grant foreground location but not background location
3. Turn off location (GPS)
4. call `show()` again

#### Checklist
- [x] Run the `pre_pr.sh` script to ensure code quality.