### PR TITLE
Fix iOS hang after denying required permission and then granted

### DIFF
--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -237,11 +237,16 @@ class _DisclosurePageState extends State<DisclosurePage>
         }
       } else {
         for (final Permission perm in item.config.permissions) {
-          // ignore: avoid-ignoring-return-values, not needed.
-          await widget._service.request(perm);
+          // ignore: prefer-moving-to-variable, multiple calls needed to ensure up-to-date data.
+          var permStatus = await widget._service.status(perm);
+          if (permStatus != PermissionStatus.permanentlyDenied) {
+            // ignore: avoid-ignoring-return-values, not needed.
+            await widget._service.request(perm);
+          }
 
           if (item.config.required) {
-            var permStatus = await widget._service.status(perm);
+            // ignore: prefer-moving-to-variable, multiple calls needed to ensure up-to-date data.
+            permStatus = await widget._service.status(perm);
             while (permStatus != PermissionStatus.granted) {
               await _showRequiredPermDialog(
                 item.config.itemText,
@@ -249,6 +254,7 @@ class _DisclosurePageState extends State<DisclosurePage>
               );
               // ignore: avoid-ignoring-return-values, not needed.
               await widget._resumed.stream.firstWhere((element) => element);
+              // ignore: prefer-moving-to-variable, multiple calls needed to ensure up-to-date data.
               permStatus = await widget._service.status(perm);
             }
           }

--- a/test/widget_test/disclosure_page_test.dart
+++ b/test/widget_test/disclosure_page_test.dart
@@ -30,6 +30,8 @@ void main() {
         .thenAnswer((realInvocation) => Future.value(prefs));
     when(testStub.request(Permission.location))
         .thenAnswer((realInvocation) => Future.value(PermissionStatus.granted));
+    when(testStub.status(Permission.location))
+        .thenAnswer((realInvocation) => Future.value(PermissionStatus.granted));
 
     final config = FlutterForcePermissionConfig(
       title: 'Title',

--- a/test/widget_test/disclosure_page_test.dart
+++ b/test/widget_test/disclosure_page_test.dart
@@ -230,6 +230,91 @@ void main() {
     await resumed.close();
   });
 
+  // If permissions are permanently denied, permission request will not show.
+  testWidgets('Required permission permanently denied', (tester) async {
+    final testStub = MockTestStub();
+    when(testStub.getSharedPreference())
+        .thenAnswer((realInvocation) => Future.value(prefs));
+    when(testStub.status(Permission.location))
+        .thenAnswer((realInvocation) => Future.value(PermissionStatus.permanentlyDenied));
+    when(testStub.openAppSettings())
+        .thenAnswer((realInvocation) => Future.value());
+
+    final config = FlutterForcePermissionConfig(
+      title: 'Title',
+      confirmText: 'Confirm',
+      permissionItemConfigs: [
+        PermissionItemConfig(
+          permissions: [
+            Permission.location,
+          ],
+          itemText: PermissionItemText(
+            header: 'Foreground location',
+            rationaleText: 'Rationale',
+            forcedPermissionDialogConfig: ForcedPermissionDialogConfig(
+              title: 'Location required',
+              text: 'Location needed for proper operation',
+              buttonText: 'Settings',
+            ),
+          ),
+          required: true,
+        ),
+      ],
+    );
+    final status = <Permission, PermissionServiceStatus>{
+      Permission.location: PermissionServiceStatus(
+        status: PermissionStatus.denied,
+        requested: false,
+        serviceStatus: ServiceStatus.enabled,
+      ),
+    };
+    final StreamController<bool> resumed = StreamController.broadcast()
+      ..add(true);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DisclosurePage.stub(
+          permissionConfig: config,
+          permissionStatuses: status,
+          service: testStub,
+          resumed: resumed,
+        ),
+      ),
+    );
+
+    expect(find.text('Title'), findsOneWidget);
+    expect(find.text('Foreground location'), findsOneWidget);
+    expect(find.text('Rationale'), findsOneWidget);
+    expect(find.text('Confirm'), findsOneWidget);
+
+    await tester.tap(find.text('Confirm'));
+    await tester.pump();
+
+    expect(find.text('Location required'), findsOneWidget);
+    expect(find.text('Location needed for proper operation'), findsOneWidget);
+    expect(find.text('Settings'), findsOneWidget);
+
+    await tester.tap(find.text('Settings'));
+    await tester.pump();
+
+    verify(testStub.openAppSettings());
+
+    resumed.add(true);
+    await tester.pump();
+
+    expect(find.text('Settings'), findsOneWidget);
+    await tester.tap(find.text('Settings'));
+
+    when(testStub.status(Permission.location))
+        .thenAnswer((realInvocation) => Future.value(PermissionStatus.granted));
+    resumed.add(true);
+    await tester.pump();
+
+    expect(find.text('Settings'), findsNothing);
+
+    await resumed.close();
+  });
+
   testWidgets('Required service permission', (tester) async {
     final testStub = MockTestStub();
     when(testStub.getSharedPreference())


### PR DESCRIPTION
#### What does this change?
Fix iOS hang after denying required permission and then granted

#### How do we test this change?
1. iOS device
2. Deny required location permission
3. Grant it in settings
4. App fail to proceed to next permission

#### Any screenshot for this change?
Post any screenshots for your feature, if any.

#### Checklist
- [x] Create suitable unit/widget tests for your change.
- [x] Run the `pre_pr.sh` script to ensure code quality.
