### PR TITLE
Add custom dialog config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 # flutter-force-permission
+
 [![codecov](https://codecov.io/gh/gogovan/flutter-force-permission/branch/main/graph/badge.svg?token=F9DPJUAVAJ)](https://codecov.io/gh/gogovan/flutter-force-permission)
 
-Show permission disclosure page and allows required permissions and their associated services before the user can proceed.
+Show permission disclosure page and allows required permissions and their associated services before
+the user can proceed.
 
-This package shows a prominent in-app disclosure page for getting permissions as required by [Google Play](https://support.google.com/googleplay/android-developer/answer/9799150?visit_id=638041800350153935-369621111&p=pd-m&rd=1#prominent_disclosure&zippy=%2Cstep-provide-prominent-in-app-disclosure%2Cstep-review-best-practices-for-accessing-location%2Cstep-consider-alternatives-to-accessing-location-in-the-background%2Cstep-make-access-to-location-in-the-background-clear-to-users%2Csee-an-example-of-prominent-in-app-disclosure).
-Also support iOS to ensure a consistent experience.
+This package shows a prominent in-app disclosure page for getting permissions as required
+by [Google Play](https://support.google.com/googleplay/android-developer/answer/9799150?visit_id=638041800350153935-369621111&p=pd-m&rd=1#prominent_disclosure&zippy=%2Cstep-provide-prominent-in-app-disclosure%2Cstep-review-best-practices-for-accessing-location%2Cstep-consider-alternatives-to-accessing-location-in-the-background%2Cstep-make-access-to-location-in-the-background-clear-to-users%2Csee-an-example-of-prominent-in-app-disclosure)
+. Also support iOS to ensure a consistent experience.
 
-In addition, permissions and their associated services (e.g. GPS) can be set as "required". If this is set, those required permissions will 
-be required and if users denied it, this package will show a customizable dialog and redirect user to the appropriate settings page provided by the native OS.
+In addition, permissions and their associated services (e.g. GPS) can be set as "required". If this
+is set, those required permissions will be required and if users denied it, this package will show a
+customizable dialog and redirect user to the appropriate settings page provided by the native OS.
 
 ## Setup
+
 1. Add the following to `pubspec.yaml`
+
 ```yaml
 dependencies:
   flutter_force_permission: ^0.1.0
   permission_handler: ^10.2.0
 ```
-2. This package depends on [permission_handler](https://pub.dev/packages/permission_handler). Perform setup according to that package.
-3. On Android, if you use `POST_NOTIFICATIONS` permission, update the `targetSdkVersion` in `build.gradle` to at least 33 so that the permission request dialog is shown correctly. Refer to [relevant Android Developer page](https://developer.android.com/develop/ui/views/notifications/notification-permission) for details.
+
+2. This package depends on [permission_handler](https://pub.dev/packages/permission_handler).
+   Perform setup according to that package.
+3. On Android, if you use `POST_NOTIFICATIONS` permission, update the `targetSdkVersion`
+   in `build.gradle` to at least 33 so that the permission request dialog is shown correctly. Refer
+   to [relevant Android Developer page](https://developer.android.com/develop/ui/views/notifications/notification-permission)
+   for details.
+
 ```groovy
 android {
     // ...
@@ -29,52 +41,134 @@ android {
     // ...
 }
 ```
-4. If any features is required, it is highly recommended to also set the `<uses-feature>` tag in AndroidManifest.xml. Refer to [relevant Android Developers page](https://developer.android.com/guide/topics/manifest/uses-feature-element) for details. 
+
+4. If any features is required, it is highly recommended to also set the `<uses-feature>` tag in
+   AndroidManifest.xml. Refer
+   to [relevant Android Developers page](https://developer.android.com/guide/topics/manifest/uses-feature-element)
+   for details.
 
 ## Usage
-1. Create an instance of FlutterForcePermission, providing configuration. Refer to documentation for [FlutterForcePermissionConfig] for details.
+
+1. Create an instance of FlutterForcePermission, providing configuration. Refer to documentation
+   for [FlutterForcePermissionConfig] for details.
+
 ```dart
+
 final perm = FlutterForcePermission(
-    FlutterForcePermissionConfig(
-      title: 'Title',
-      permissionItemConfigs: [
-        PermissionItemConfig(
-          permissions: [Permission.locationWhenInUse],
-          required: true,
-          itemText: PermissionItemText(
-            header: 'Foreground Location',
-            rationaleText: 'Rationale for Foreground location. Required.',
-            forcedPermissionDialogConfig: ForcedPermissionDialogConfig(
-              title: 'Please enable location permission',
-              text: 'Please enable location permission for proper usage.',
-              buttonText: 'Settings',
-            ),
+  FlutterForcePermissionConfig(
+    title: 'Title',
+    permissionItemConfigs: [
+      PermissionItemConfig(
+        permissions: [Permission.locationWhenInUse],
+        required: true,
+        itemText: PermissionItemText(
+          header: 'Foreground Location',
+          rationaleText: 'Rationale for Foreground location. Required.',
+          forcedPermissionDialogConfig: ForcedPermissionDialogConfig(
+            title: 'Please enable location permission',
+            text: 'Please enable location permission for proper usage.',
+            buttonText: 'Settings',
           ),
         ),
-        PermissionItemConfig(
-          permissions: [Permission.locationAlways],
-          itemText: PermissionItemText(
-            header: 'Background Location',
-            rationaleText: 'Rationale for Background location. lorem ipsum dolor sit amet.',
-          ),
+      ),
+      PermissionItemConfig(
+        permissions: [Permission.locationAlways],
+        itemText: PermissionItemText(
+          header: 'Background Location',
+          rationaleText: 'Rationale for Background location. lorem ipsum dolor sit amet.',
         ),
-      ],
-    ),
-  );
+      ),
+    ],
+  ),
+);
 ```
-2. Show the disclosure page as needed. This method will handle showing the disclosure page and requesting permissions.
-This function takes a [NavigatorState](https://api.flutter.dev/flutter/widgets/NavigatorState-class.html) which can be retrieved through `Navigator.of(context)` call.
-This is an async function. Wrap the function in an `async` block as needed.
-Returns a map of permission and their requested status (granted/denied/etc), service status and whether they are requested by this plugin.
+
+2. Show the disclosure page as needed. This method will handle showing the disclosure page and
+   requesting permissions. This function takes
+   a [NavigatorState](https://api.flutter.dev/flutter/widgets/NavigatorState-class.html) which can
+   be retrieved through `Navigator.of(context)` call. This is an async function. Wrap the function
+   in an `async` block as needed. Returns a map of permission and their requested status (
+   granted/denied/etc), service status and whether they are requested by this plugin.
+
 ```dart
-final result = await perm.show(Navigator.of(context));
+
+final result = await
+perm.show(Navigator.of(context));
 ```
 
 ### Styling
-You can set the style of the text shown by setting up a [TextTheme](https://api.flutter.dev/flutter/material/TextTheme-class.html) of the provided context. 
+
+You can set the style of the text shown by setting up
+a [TextTheme](https://api.flutter.dev/flutter/material/TextTheme-class.html) of the provided
+context.
+
 - Title uses `headline6` text style.
 - Item header use `subtitle1` text style.
 - Item body use `bodyText2` text style.
+
+## Advanced Usage
+
+### Customize the required permission denied prompt
+
+If you wish to customize the dialog shown when the required permission is denied, provide
+a `showDialogCallback` which to show your dialog. Parameters are included for you to compose the
+appropriate dialog. In your callback, you SHOULD:
+
+1. Display a non-dismissable dialog. This can be typically achieved by setting `barrierDismissible`
+   to false and provide an empty callback e.g. (`() async => false`) to `willPopCallback` for your
+   dialog.
+2. Call the provided `callback` parameter in your callback when the user click the confirm button,
+   and dismiss your dialog by `Navigator.pop`.
+
+```dart
+
+final config = FlutterForcePermissionConfig(
+  title: 'Title',
+  confirmText: 'Confirm',
+  permissionItemConfigs: [
+    PermissionItemConfig(
+      permissions: [
+        Permission.location,
+      ],
+      itemText: PermissionItemText(
+        header: 'Foreground location',
+        rationaleText: 'Rationale',
+        forcedPermissionDialogConfig: ForcedPermissionDialogConfig(
+          title: 'Location required',
+          text: 'Location needed for proper operation',
+          buttonText: 'Settings',
+        ),
+      ),
+      required: true,
+    ),
+  ],
+  showDialogCallback: (context, title, text, button, callback) {
+    // Store the navigator to avoid storing contexts across async gaps. See https://stackoverflow.com/a/69512692/11675817 for details.
+    final navigator = Navigator.of(context);
+    // Show your dialog.
+    showDialog(context: context,
+      barrierDismissible: false,
+      builder: (context) =>
+          WillPopScope(
+            onWillPop: () async => false,
+            child: AlertDialog(
+              title: Text(title),
+              content: Text(text),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    callback();
+                    navigator.pop();
+                  },
+                  child: Text(button),
+                ),
+              ],
+            ),
+          ),
+    );
+  },
+);
+```
 
 ## Issues
 

--- a/lib/flutter_force_permission_config.dart
+++ b/lib/flutter_force_permission_config.dart
@@ -1,6 +1,9 @@
 library flutter_force_permission;
 
+import 'package:flutter/material.dart';
 import 'package:flutter_force_permission/permission_item_config.dart';
+
+typedef ShowDialogCallback = void Function(String title, String content, String buttonText, VoidCallback callback);
 
 /// Configuration for Flutter Force Permission.
 class FlutterForcePermissionConfig {
@@ -8,6 +11,7 @@ class FlutterForcePermissionConfig {
     required this.title,
     required this.confirmText,
     required this.permissionItemConfigs,
+    this.showDialogCallback,
   });
 
   /// The title for the disclosure page.
@@ -21,4 +25,16 @@ class FlutterForcePermissionConfig {
   /// The list ordering dictates the order of the permissions requested in the disclosure page and the order the OS shows the permission dialogs.
   /// See [PermissionItemConfig] for details.
   final List<PermissionItemConfig> permissionItemConfigs;
+
+  /// Optional callback to show a custom dialog. If you wish to use dialogs other than
+  /// the provided Material Design dialogs, provide a callback in this parameter.
+  /// The parameters provided to the callback consists of all the texts to be shown
+  /// as `title`, `content` and the confirm button `buttonText` respectively, as well
+  /// as a `callback` for you to call when the confirm button is clicked.
+  ///
+  /// This callback SHOULD invoke the provided `callback` in your callback to ensure proper functionality by invoking system OS settings.
+  /// The dialog shown during your callback SHOULD NOT be dismissable. It is typically
+  /// achieved by setting `barrierDismissible` to false and provide an empty callback
+  /// e.g. (`() async => false`) to `willPopCallback` for your dialog.
+  final ShowDialogCallback? showDialogCallback;
 }

--- a/lib/flutter_force_permission_config.dart
+++ b/lib/flutter_force_permission_config.dart
@@ -3,7 +3,7 @@ library flutter_force_permission;
 import 'package:flutter/material.dart';
 import 'package:flutter_force_permission/permission_item_config.dart';
 
-typedef ShowDialogCallback = void Function(String title, String content, String buttonText, VoidCallback callback);
+typedef ShowDialogCallback = void Function(BuildContext context, String title, String content, String buttonText, VoidCallback callback);
 
 /// Configuration for Flutter Force Permission.
 class FlutterForcePermissionConfig {
@@ -32,9 +32,11 @@ class FlutterForcePermissionConfig {
   /// as `title`, `content` and the confirm button `buttonText` respectively, as well
   /// as a `callback` for you to call when the confirm button is clicked.
   ///
-  /// This callback SHOULD invoke the provided `callback` in your callback to ensure proper functionality by invoking system OS settings.
+  /// This callback SHOULD invoke the provided `callback` in your callback upon confirmation
+  /// to ensure proper functionality as the `callback` will invoke appropriate setting pages provided by the OS.
   /// The dialog shown during your callback SHOULD NOT be dismissable. It is typically
   /// achieved by setting `barrierDismissible` to false and provide an empty callback
   /// e.g. (`() async => false`) to `willPopCallback` for your dialog.
+  /// Also, you will probably need to dismiss your dialog after confirmation.
   final ShowDialogCallback? showDialogCallback;
 }

--- a/lib/flutter_force_permission_config.dart
+++ b/lib/flutter_force_permission_config.dart
@@ -3,7 +3,13 @@ library flutter_force_permission;
 import 'package:flutter/material.dart';
 import 'package:flutter_force_permission/permission_item_config.dart';
 
-typedef ShowDialogCallback = void Function(BuildContext context, String title, String content, String buttonText, VoidCallback callback);
+typedef ShowDialogCallback = void Function(
+  BuildContext context,
+  String title,
+  String content,
+  String buttonText,
+  VoidCallback callback,
+);
 
 /// Configuration for Flutter Force Permission.
 class FlutterForcePermissionConfig {

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -273,54 +273,53 @@ class _DisclosurePageState extends State<DisclosurePage>
     VoidCallback openSettings,
   ) async {
     final dialogConfig = permConfig.forcedPermissionDialogConfig;
-    // ignore: avoid-ignoring-return-values, not needed.
-    await showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) => WillPopScope(
-        onWillPop: () async => false,
-        child: AlertDialog(
-          title: Text(
-            dialogConfig?.title ?? '',
-          ),
-          content: Text(
-            dialogConfig?.text ?? '',
-          ),
-          actions: [
-            TextButton(
-              onPressed: openSettings,
-              child: Text(
-                dialogConfig?.buttonText ?? '',
-              ),
+    final callback = widget.permissionConfig.showDialogCallback;
+
+    if (callback == null) {
+      // ignore: avoid-ignoring-return-values, not needed.
+      await showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => WillPopScope(
+          onWillPop: () async => false,
+          child: AlertDialog(
+            title: Text(
+              dialogConfig?.title ?? '',
             ),
-          ],
+            content: Text(
+              dialogConfig?.text ?? '',
+            ),
+            actions: [
+              TextButton(
+                onPressed: openSettings,
+                child: Text(
+                  dialogConfig?.buttonText ?? '',
+                ),
+              ),
+            ],
+          ),
         ),
-      ),
-    );
+      );
+    } else {
+      callback(
+        dialogConfig?.title ?? '',
+        dialogConfig?.text ?? '',
+        dialogConfig?.buttonText ?? '',
+        openSettings,
+      );
+    }
   }
 
   Future<void> _showPhoneSettings() async {
-    final navigator = Navigator.of(context);
-
     // TODO(peter): find function to open phone settings directly if possible.
     await widget._service.openAppSettings();
-
-    navigator.pop();
   }
 
   Future<void> _showLocationSettings() async {
-    final navigator = Navigator.of(context);
-
     await widget._service.openLocationSettings();
-
-    navigator.pop();
   }
 
   Future<void> _showAppSettings() async {
-    final navigator = Navigator.of(context);
-
     await widget._service.openAppSettings();
-
-    navigator.pop();
   }
 }

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -272,6 +272,7 @@ class _DisclosurePageState extends State<DisclosurePage>
     PermissionItemText permConfig,
     VoidCallback openSettings,
   ) async {
+    final navigator = Navigator.of(context);
     final dialogConfig = permConfig.forcedPermissionDialogConfig;
     final callback = widget.permissionConfig.showDialogCallback;
 
@@ -291,7 +292,10 @@ class _DisclosurePageState extends State<DisclosurePage>
             ),
             actions: [
               TextButton(
-                onPressed: openSettings,
+                onPressed: () {
+                  openSettings();
+                  navigator.pop();
+                },
                 child: Text(
                   dialogConfig?.buttonText ?? '',
                 ),

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -302,6 +302,7 @@ class _DisclosurePageState extends State<DisclosurePage>
       );
     } else {
       callback(
+        context,
         dialogConfig?.title ?? '',
         dialogConfig?.text ?? '',
         dialogConfig?.buttonText ?? '',

--- a/test/widget_test/disclosure_page_test.dart
+++ b/test/widget_test/disclosure_page_test.dart
@@ -443,7 +443,7 @@ void main() {
           required: true,
         ),
       ],
-      showDialogCallback: (title, text, button, callback) {
+      showDialogCallback: (context, title, text, button, callback) {
         callback();
       },
     );

--- a/test/widget_test/disclosure_page_test.dart
+++ b/test/widget_test/disclosure_page_test.dart
@@ -411,4 +411,84 @@ void main() {
 
     await resumed.close();
   });
+
+  testWidgets('Required permission denied with custom dialog callback `showDialogCallback`', (tester) async {
+    final testStub = MockTestStub();
+    when(testStub.getSharedPreference())
+        .thenAnswer((realInvocation) => Future.value(prefs));
+    when(testStub.request(Permission.location))
+        .thenAnswer((realInvocation) => Future.value(PermissionStatus.denied));
+    when(testStub.status(Permission.location))
+        .thenAnswer((realInvocation) => Future.value(PermissionStatus.denied));
+    when(testStub.openAppSettings())
+        .thenAnswer((realInvocation) => Future.value());
+
+    final config = FlutterForcePermissionConfig(
+      title: 'Title',
+      confirmText: 'Confirm',
+      permissionItemConfigs: [
+        PermissionItemConfig(
+          permissions: [
+            Permission.location,
+          ],
+          itemText: PermissionItemText(
+            header: 'Foreground location',
+            rationaleText: 'Rationale',
+            forcedPermissionDialogConfig: ForcedPermissionDialogConfig(
+              title: 'Location required',
+              text: 'Location needed for proper operation',
+              buttonText: 'Settings',
+            ),
+          ),
+          required: true,
+        ),
+      ],
+      showDialogCallback: (title, text, button, callback) {
+        callback();
+      },
+    );
+    final status = <Permission, PermissionServiceStatus>{
+      Permission.location: PermissionServiceStatus(
+        status: PermissionStatus.denied,
+        requested: false,
+        serviceStatus: ServiceStatus.enabled,
+      ),
+    };
+    final StreamController<bool> resumed = StreamController.broadcast()
+      ..add(true);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DisclosurePage.stub(
+          permissionConfig: config,
+          permissionStatuses: status,
+          service: testStub,
+          resumed: resumed,
+        ),
+      ),
+    );
+
+    expect(find.text('Title'), findsOneWidget);
+    expect(find.text('Foreground location'), findsOneWidget);
+    expect(find.text('Rationale'), findsOneWidget);
+    expect(find.text('Confirm'), findsOneWidget);
+
+    await tester.tap(find.text('Confirm'));
+    await tester.pump();
+
+    verify(testStub.openAppSettings());
+
+    resumed.add(true);
+    await tester.pump();
+
+    when(testStub.status(Permission.location))
+        .thenAnswer((realInvocation) => Future.value(PermissionStatus.granted));
+    resumed.add(true);
+    await tester.pump();
+
+    verify(testStub.openAppSettings());
+    expect(find.text('Settings'), findsNothing);
+
+    await resumed.close();
+  });
 }


### PR DESCRIPTION
#### What does this change?
Add a custom dialog callback feature. This is to allow client code to customize the dialog shown when a required permission is denied.

#### How do we test this change?
1. 

#### Checklist
- [x] Create suitable unit/widget tests for your change.
- [x] Run the `pre_pr.sh` script to ensure code quality.
