### PR TITLE
Updater permission handle dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flutter-force-permission
 
-![Build](https://github.com/github/gogovan/flutter-force-permission/workflows/build.yaml/badge.svg)
+![Build](https://github.com/gogovan/flutter-force-permission/actions/workflows/build.yaml/badge.svg)
 ![codecov](https://codecov.io/gh/gogovan/flutter-force-permission/branch/main/graph/badge.svg?token=F9DPJUAVAJ)
 
 Show permission disclosure page and allows required permissions and their associated services before
@@ -170,6 +170,13 @@ final config = FlutterForcePermissionConfig(
   },
 );
 ```
+
+## Known Issues
+
+- Currently it depends on our fork
+  of [`flutter-permission-handler`](https://github.com/gogovan/flutter-permission-handler) instead
+  of the original to fix an issue for iOS. You may track the
+  issue and pull request [here](https://github.com/Baseflow/flutter-permission-handler/pull/967).
 
 ## Issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,10 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.8.0
-  permission_handler: ^10.2.0
+  permission_handler:
+    git:
+      url: https://github.com/gogovan/flutter-permission-handler.git
+      ref: master
   app_settings: ^4.1.8
   shared_preferences: ^2.0.15
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     git:
       url: https://github.com/gogovan/flutter-permission-handler.git
       ref: master
+      path: permission_handler
   app_settings: ^4.1.8
   shared_preferences: ^2.0.15
 


### PR DESCRIPTION
#### What does this change?
Update `permission_handler` dependency to fix iOS issue.

#### How do we test this change?
1. Use iOS when requesting app tracking transparency permission. For details see https://github.com/Baseflow/flutter-permission-handler/pull/967.

#### Any screenshot for this change?
Post any screenshots for your feature, if any.

#### Checklist
- [ ] Create suitable unit/widget tests for your change.
- [x] Run the `pre_pr.sh` script to ensure code quality.
