### PR TITLE
Allow custom styling parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0
 
 - Add styling support for permission request page.
+- Center the title.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
-## 0.0.1
+## 0.2.0
 
-* TODO: Describe initial release.
+- Add styling support for permission request page.
+
+## 0.1.0
+
+- Initial release.
+

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ in the configuration.
 
 - `elevatedButtonTheme.style` is used for the primary button.
 - `primaryColor` is used for as the color of the icons.
-- Title uses `headline6` text style.
-- Item header use `subtitle1` text style.
-- Item body use `bodyText2` text style.
+- Title uses `titleLarge` text style.
+- Item header use `titleMedium` text style.
+- Item body use `bodyMedium` text style.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ final result = await perm.show(Navigator.of(context));
 ### Styling
 
 You can set the styles by providing a [ThemeData](https://api.flutter.dev/flutter/material/ThemeData-class.html)
-when calling `show` to show the permission request page.
+in the configuration.
 
 - `elevatedButtonTheme.style` is used for the primary button.
 - `primaryColor` is used for as the color of the icons.

--- a/README.md
+++ b/README.md
@@ -112,17 +112,16 @@ final perm = FlutterForcePermission(
    granted/denied/etc), service status and whether they are requested by this plugin.
 
 ```dart
-
-final result = await
-perm.show(Navigator.of(context));
+final result = await perm.show(Navigator.of(context));
 ```
 
 ### Styling
 
-You can set the style of the text shown by setting up
-a [TextTheme](https://api.flutter.dev/flutter/material/TextTheme-class.html) of the provided
-context.
+You can set the styles by providing a [ThemeData](https://api.flutter.dev/flutter/material/ThemeData-class.html)
+when calling `show` to show the permission request page.
 
+- `elevatedButtonTheme.style` is used for the primary button.
+- `primaryColor` is used for as the color of the icons.
 - Title uses `headline6` text style.
 - Item header use `subtitle1` text style.
 - Item body use `bodyText2` text style.

--- a/lib/flutter_force_permission_config.dart
+++ b/lib/flutter_force_permission_config.dart
@@ -18,6 +18,7 @@ class FlutterForcePermissionConfig {
     required this.confirmText,
     required this.permissionItemConfigs,
     this.showDialogCallback,
+    this.themeData,
   });
 
   /// The title for the disclosure page.
@@ -45,4 +46,8 @@ class FlutterForcePermissionConfig {
   /// e.g. (`() async => false`) to `willPopCallback` for your dialog.
   /// Also, you will probably need to dismiss your dialog after confirmation.
   final ShowDialogCallback? showDialogCallback;
+
+  /// Optional theme data for the disclosure page.
+  /// If none is provided, theme data from the default Context is used.
+  final ThemeData? themeData;
 }

--- a/lib/src/flutter_force_permission_util.dart
+++ b/lib/src/flutter_force_permission_util.dart
@@ -1,3 +1,3 @@
 import 'package:permission_handler/permission_handler.dart';
 
-String getRequestedPrefKey(Permission perm) => '${perm.toString()}_requested';
+String getRequestedPrefKey(Permission perm) => '${perm}_requested';

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -121,7 +121,7 @@ class _DisclosurePageState extends State<DisclosurePage>
         const SizedBox(height: 64),
         Text(
           widget.permissionConfig.title,
-          style: theme.textTheme.headline6,
+          style: theme.textTheme.titleLarge,
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 16),
@@ -165,7 +165,7 @@ class _DisclosurePageState extends State<DisclosurePage>
                               Flexible(
                                 child: Text(
                                   config?.header ?? '',
-                                  style: theme.textTheme.subtitle1,
+                                  style: theme.textTheme.titleMedium,
                                   softWrap: true,
                                   overflow: TextOverflow.ellipsis,
                                   maxLines: DisclosurePage.maxLines,
@@ -174,7 +174,7 @@ class _DisclosurePageState extends State<DisclosurePage>
                               Flexible(
                                 child: Text(
                                   config?.rationaleText ?? '',
-                                  style: theme.textTheme.bodyText2,
+                                  style: theme.textTheme.bodyMedium,
                                   softWrap: true,
                                   overflow: TextOverflow.ellipsis,
                                   maxLines: DisclosurePage.maxLines,

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -122,6 +122,7 @@ class _DisclosurePageState extends State<DisclosurePage>
         Text(
           widget.permissionConfig.title,
           style: theme.textTheme.headline6,
+          textAlign: TextAlign.center,
         ),
         const SizedBox(height: 16),
       ],

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -114,12 +114,14 @@ class _DisclosurePageState extends State<DisclosurePage>
 
   @override
   Widget build(BuildContext context) {
+    final theme = widget.permissionConfig.themeData ?? Theme.of(context);
+
     final titleWidget = Column(
       children: [
         const SizedBox(height: 64),
         Text(
           widget.permissionConfig.title,
-          style: Theme.of(context).textTheme.headline6,
+          style: theme.textTheme.headline6,
         ),
         const SizedBox(height: 16),
       ],
@@ -146,7 +148,7 @@ class _DisclosurePageState extends State<DisclosurePage>
                   var icon = config?.icon;
                   icon ??= Icon(
                     Icons.perm_device_info_sharp,
-                    color: Theme.of(context).primaryColor,
+                    color: theme.primaryColor,
                   );
 
                   return Center(
@@ -162,7 +164,7 @@ class _DisclosurePageState extends State<DisclosurePage>
                               Flexible(
                                 child: Text(
                                   config?.header ?? '',
-                                  style: Theme.of(context).textTheme.subtitle1,
+                                  style: theme.textTheme.subtitle1,
                                   softWrap: true,
                                   overflow: TextOverflow.ellipsis,
                                   maxLines: DisclosurePage.maxLines,
@@ -171,7 +173,7 @@ class _DisclosurePageState extends State<DisclosurePage>
                               Flexible(
                                 child: Text(
                                   config?.rationaleText ?? '',
-                                  style: Theme.of(context).textTheme.bodyText2,
+                                  style: theme.textTheme.bodyText2,
                                   softWrap: true,
                                   overflow: TextOverflow.ellipsis,
                                   maxLines: DisclosurePage.maxLines,
@@ -192,6 +194,7 @@ class _DisclosurePageState extends State<DisclosurePage>
             padding: const EdgeInsets.all(16),
             child: ElevatedButton(
               onPressed: () => _onGrantPermission(context),
+              style: theme.elevatedButtonTheme.style,
               child: Text(widget.permissionConfig.confirmText),
             ),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_force_permission
 description: Show permission disclosure page and allows required permissions before user can proceed.
-version: 0.1.0
+version: 0.2.0
 homepage: https://gogovan.hk
 
 publish_to: none


### PR DESCRIPTION
#### What does this change?
Allow custom styling parameter in configuration so client code can change the style of the text.

#### How do we test this change?
Use the new `themeData` parameter in configuration

#### Any screenshot for this change?
![Screenshot_20230130_153435](https://user-images.githubusercontent.com/1821496/215415204-7a890584-c741-45d7-bebe-96098a16156e.png)

#### Checklist
- [x] Create suitable unit/widget tests for your change.
- [x] Run the `pre_pr.sh` script to ensure code quality.
