### PR TITLE
Fix custom dialog callback not waiting

### DIFF
--- a/lib/flutter_force_permission_config.dart
+++ b/lib/flutter_force_permission_config.dart
@@ -5,7 +5,7 @@ import 'package:flutter_force_permission/permission_item_config.dart';
 import 'package:flutter_force_permission/permission_item_text.dart';
 import 'package:flutter_force_permission/permission_required_option.dart';
 
-typedef ShowDialogCallback = void Function(
+typedef ShowDialogCallback = Future<void> Function(
   BuildContext context,
   PermissionRequiredOption option,
   PermissionItemText? permConfig,
@@ -36,16 +36,21 @@ class FlutterForcePermissionConfig {
 
   /// Optional callback to show a custom dialog. If you wish to use dialogs other than
   /// the provided Material Design dialogs, provide a callback in this parameter.
-  /// The parameters provided to the callback consists of all the texts to be shown
-  /// as `title`, `content` and the confirm button `buttonText` respectively, as well
-  /// as a `callback` for you to call when the confirm button is clicked.
+  /// The parameters provided to the callback consists of the following:
+  /// `context`: Use this context to build your dialogs.
+  /// `option`: Indicates the PermissionRequiredOption for this dialog.
+  ///   If this is `ask`, provide two buttons, one to dismiss the dialog and the other to show settings page by calling `callback`.
+  ///   If this is `required`, provide one button which show settings page by calling `callback`.
+  /// `permConfig`: Configuration for the item, contains all the text that you need to show.
+  /// `callback`: Calls this callback when the user confirms the action to show settings page.
   ///
   /// This callback SHOULD invoke the provided `callback` in your callback upon confirmation
   /// to ensure proper functionality as the `callback` will invoke appropriate setting pages provided by the OS.
   /// The dialog shown during your callback SHOULD NOT be dismissable. It is typically
   /// achieved by setting `barrierDismissible` to false and provide an empty callback
   /// e.g. (`() async => false`) to `willPopCallback` for your dialog.
-  /// Also, you will probably need to dismiss your dialog after confirmation.
+  ///
+  /// Also, you will need to dismiss your dialog after confirmation.
   final ShowDialogCallback? showDialogCallback;
 
   /// Optional theme data for the disclosure page.

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -347,7 +347,7 @@ class _DisclosurePageState extends State<DisclosurePage>
         ),
       );
     } else {
-      callback(
+      await callback(
         context,
         option,
         permConfig,

--- a/test/widget_test/disclosure_page_test.dart
+++ b/test/widget_test/disclosure_page_test.dart
@@ -423,7 +423,7 @@ void main() {
               required: PermissionRequiredOption.required,
             ),
           ],
-          showDialogCallback: (context, option, config, callback) {
+          showDialogCallback: (context, option, config, callback) async {
             callback();
           },
         ),


### PR DESCRIPTION
#### What does this change?
Fix custom dialog callback not waiting. This results in using custom dialog callback with `PermissionRequiredOption.ask` to fail to show dialogs in some cases.
Also updated the doc for the callback usage.

#### How do we test this change?
1. Use custom dialog.

#### Any screenshot for this change?
Post any screenshots for your feature, if any.

#### Checklist
- [ ] Create suitable unit/widget tests for your change.
- [x] Run the `pre_pr.sh` script to ensure code quality.
