### PR TITLE
Add codecov coverage to build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,11 @@ jobs:
           flutter pub get
           flutter pub run build_runner build
 
-      - name: Run tests
-        run: flutter test
+      - name: Run tests and generate coverage report
+          run: flutter test --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./coverage
 


### PR DESCRIPTION
#### What does this change?
Add Codecov coverage step to Github Actions build so that the BASE for Codecov is always up to date.

#### How do we test this change?
N/A 

#### Any screenshot for this change?
N/A 

#### Checklist
- [ ] Create suitable unit/widget tests for your change.
- [x] Run the `pre_pr.sh` script to ensure code quality.
