### PR TITLE
Avoid repeat invocation of disclosure page when 'ask' is used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ android {
 ## Usage
 
 1. Create an instance of FlutterForcePermission, providing configuration. Refer to documentation
-   for [FlutterForcePermissionConfig] for details.
+   of [FlutterForcePermissionConfig] for configuration details. Use a single instance of `FlutterForcePermission` throughout your app.
 
 ```dart
 

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -26,6 +26,8 @@ class FlutterForcePermission {
 
   bool _showing = false;
 
+  final _requestedInSession = <Permission, bool>{};
+
   /// Show disclosure page.
   ///
   /// This will show the disclosure page according to the provided configuration, and handles requesting permissions.
@@ -57,7 +59,8 @@ class FlutterForcePermission {
         }
         if (perm is PermissionWithService &&
             permissionStatuses[perm]?.serviceStatus == ServiceStatus.disabled &&
-            permConfig.required != PermissionRequiredOption.none) {
+            permConfig.required != PermissionRequiredOption.none &&
+            _requestedInSession[perm] != true) {
           needShow = true;
           break;
         }
@@ -80,6 +83,14 @@ class FlutterForcePermission {
     );
 
     _showing = false;
+
+    for (final permConfig in config.permissionItemConfigs) {
+      for (final perm in permConfig.permissions) {
+        if (permConfig.required != PermissionRequiredOption.required) {
+          _requestedInSession[perm] = true;
+        }
+      }
+    }
 
     // Check for permission status again as it is likely updated.
     return getPermissionStatuses();

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -57,26 +57,7 @@ class FlutterForcePermission {
       return permissionStatuses;
     }
 
-    var needShow = false;
-    for (final permConfig in config.permissionItemConfigs) {
-      for (final perm in permConfig.permissions) {
-        if (permissionStatuses[perm]?.status != PermissionStatus.granted &&
-                (permConfig.required == PermissionRequiredOption.required) ||
-            !(permissionStatuses[perm]?.requested ?? true) ||
-            (permConfig.required == PermissionRequiredOption.ask &&
-                _requestedInSession[perm] != true)) {
-          needShow = true;
-          break;
-        }
-        if (perm is PermissionWithService &&
-            permissionStatuses[perm]?.serviceStatus == ServiceStatus.disabled &&
-            permConfig.required != PermissionRequiredOption.none &&
-            _requestedInSession[perm] != true) {
-          needShow = true;
-          break;
-        }
-      }
-    }
+    final bool needShow = isShowPermissionPage(permissionStatuses);
 
     if (!needShow) {
       return permissionStatuses;
@@ -105,6 +86,33 @@ class FlutterForcePermission {
 
     // Check for permission status again as it is likely updated.
     return getPermissionStatuses();
+  }
+
+  bool isShowPermissionPage(
+    Map<Permission, PermissionServiceStatus> permissionStatuses,
+  ) {
+    var needShow = false;
+    for (final permConfig in config.permissionItemConfigs) {
+      for (final perm in permConfig.permissions) {
+        if (permissionStatuses[perm]?.status != PermissionStatus.granted &&
+                (permConfig.required == PermissionRequiredOption.required) ||
+            !(permissionStatuses[perm]?.requested ?? true) ||
+            (permConfig.required == PermissionRequiredOption.ask &&
+                _requestedInSession[perm] != true)) {
+          needShow = true;
+          break;
+        }
+        if (perm is PermissionWithService &&
+            permissionStatuses[perm]?.serviceStatus == ServiceStatus.disabled &&
+            permConfig.required != PermissionRequiredOption.none &&
+            _requestedInSession[perm] != true) {
+          needShow = true;
+          break;
+        }
+      }
+    }
+
+    return needShow;
   }
 
   /// Get all permission statuses.

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -35,8 +35,7 @@ class FlutterForcePermission {
   /// Returns a map of Permission and their status after requesting the permissions.
   /// Only permissions specified in the configuration will be included in the return value.
   Future<Map<Permission, PermissionServiceStatus>> show(
-    NavigatorState navigator,
-  ) async {
+      NavigatorState navigator,) async {
     // Check for permissions.
     final permissionStatuses = await getPermissionStatuses();
     if (_showing) return permissionStatuses;
@@ -52,8 +51,10 @@ class FlutterForcePermission {
     for (final permConfig in config.permissionItemConfigs) {
       for (final perm in permConfig.permissions) {
         if (permissionStatuses[perm]?.status != PermissionStatus.granted &&
-            (permConfig.required != PermissionRequiredOption.none ||
-                !(permissionStatuses[perm]?.requested ?? true))) {
+            (permConfig.required == PermissionRequiredOption.required) ||
+            !(permissionStatuses[perm]?.requested ?? true) ||
+            (permConfig.required == PermissionRequiredOption.ask &&
+                _requestedInSession[perm] != true)) {
           needShow = true;
           break;
         }
@@ -75,10 +76,11 @@ class FlutterForcePermission {
     // ignore: avoid-ignoring-return-values, not needed.
     await navigator.push(
       MaterialPageRoute(
-        builder: (context) => DisclosurePage(
-          permissionConfig: config,
-          permissionStatuses: permissionStatuses,
-        ),
+        builder: (context) =>
+            DisclosurePage(
+              permissionConfig: config,
+              permissionStatuses: permissionStatuses,
+            ),
       ),
     );
 
@@ -100,11 +102,11 @@ class FlutterForcePermission {
   ///
   /// Only permissions specified in the configuration will be queried and returned.
   Future<Map<Permission, PermissionServiceStatus>>
-      getPermissionStatuses() async {
+  getPermissionStatuses() async {
     final prefs = await _service.getSharedPreference();
     final Map<Permission, PermissionServiceStatus> result = {};
     for (final List<Permission> perms
-        in config.permissionItemConfigs.map((e) => e.permissions)) {
+    in config.permissionItemConfigs.map((e) => e.permissions)) {
       for (final Permission perm in perms) {
         final status = await _service.status(perm);
         final requested = prefs.getBool(getRequestedPrefKey(perm)) ?? false;

--- a/lib/flutter_force_permission_config.dart
+++ b/lib/flutter_force_permission_config.dart
@@ -5,7 +5,7 @@ import 'package:flutter_force_permission/permission_item_config.dart';
 import 'package:flutter_force_permission/permission_item_text.dart';
 import 'package:flutter_force_permission/permission_required_option.dart';
 
-typedef ShowDialogCallback = Future<void> Function(
+typedef ShowDialogCallback = Future<bool> Function(
   BuildContext context,
   PermissionRequiredOption option,
   PermissionItemText? permConfig,

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -347,6 +347,7 @@ class _DisclosurePageState extends State<DisclosurePage>
         ),
       );
     } else {
+      // ignore: avoid-ignoring-return-values, not needed. Using void failed to build.
       await callback(
         context,
         option,

--- a/pre_pr.sh
+++ b/pre_pr.sh
@@ -4,8 +4,8 @@ set -e
 # show debug log
 set -x
 
-flutter format lib
-flutter format test
+dart format lib
+dart format test
 flutter analyze --fatal-infos --fatal-warnings
 flutter pub run dart_code_metrics:metrics analyze lib --fatal-style --fatal-warnings --fatal-performance --set-exit-on-violation-level=warning
 

--- a/test/unit_test/flutter_force_permission_test.dart
+++ b/test/unit_test/flutter_force_permission_test.dart
@@ -53,6 +53,7 @@ void main() {
 
 Future<void> _test({
   prefRequested = false,
+  prefSessionRequested = false,
   permissionStatus = PermissionStatus.denied,
   serviceStatus = ServiceStatus.enabled,
   permissionRequired = PermissionRequiredOption.none,
@@ -90,7 +91,12 @@ Future<void> _test({
     ],
   );
 
-  final instance = FlutterForcePermission.stub(config, testStub);
+  final Map<Permission, bool> prefSession = {};
+  if (prefSessionRequested) {
+    prefSession[Permission.location] = true;
+  }
+
+  final instance = FlutterForcePermission.stub(config, testStub, prefSession);
   final result = await instance.show(navigator);
 
   if (expectNavigatorPushed) {

--- a/test/widget_test/disclosure_page_test.dart
+++ b/test/widget_test/disclosure_page_test.dart
@@ -425,6 +425,8 @@ void main() {
           ],
           showDialogCallback: (context, option, config, callback) async {
             callback();
+
+            return true;
           },
         ),
         verification: (resumed) async {


### PR DESCRIPTION
#### What does this change?
Avoid repeat invocation of disclosure page when `PermissionRequiredOption.ask` is used, as long as the same instance of `FlutterForcePermission` is used.

#### How do we test this change?
Use `PermissionRequiredOption.ask` in config and reject the permission

#### Any screenshot for this change?
Post any screenshots for your feature, if any.

#### Checklist
- [ ] Create suitable unit/widget tests for your change.
- [ ] Run the `pre_pr.sh` script to ensure code quality.
