### PR TITLE
Use own navigator instead of passed in one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ dependencies:
   flutter_force_permission: ^0.1.0
   # Currently this package depends on our `flutter-permission-handler` package to fix an iOS issue.
   # Directly depends on our packages to avoid any pubspec dependency resolving failure.
+  # Track the PR at: https://github.com/Baseflow/flutter-permission-handler/pull/967
   # TODO replace once we upload our packages and our PR merged by Baseflow.
   permission_handler:
      git:
@@ -105,14 +106,12 @@ final perm = FlutterForcePermission(
 ```
 
 2. Show the disclosure page as needed. This method will handle showing the disclosure page and
-   requesting permissions. This function takes
-   a [NavigatorState](https://api.flutter.dev/flutter/widgets/NavigatorState-class.html) which can
-   be retrieved through `Navigator.of(context)` call. This is an async function. Wrap the function
+   requesting permissions. This function takes a `BuildContext`. This is an async function. Wrap the function
    in an `async` block as needed. Returns a map of permission and their requested status (
    granted/denied/etc), service status and whether they are requested by this plugin.
 
 ```dart
-final result = await perm.show(Navigator.of(context));
+final result = await perm.show(context);
 ```
 
 ### Styling

--- a/README.md
+++ b/README.md
@@ -162,22 +162,23 @@ final config = FlutterForcePermissionConfig(
     ),
   ],
   showDialogCallback: (context, option, permConfig, callback) {
-    // Store the navigator to avoid storing contexts across async gaps. See https://stackoverflow.com/a/69512692/11675817 for details.
-    final navigator = Navigator.of(context);
     // Show your dialog.
     showDialog(context: context,
       barrierDismissible: false,
       builder: (context) =>
           WillPopScope(
-            onWillPop: () async => false,
+            onWillPop: () async => false, // Prevent dismissing dialog by tapping outside the dialog or the back button.
             child: AlertDialog(
               title: Text(permConfig.forcedPermissionDialogConfig.title),
               content: Text(permConfig.forcedPermissionDialogConfig.text),
               actions: [
                 TextButton(
                   onPressed: () {
+                    // Remember to invoke `callback` after confirm action to show the OS settings page as appropriate. 
                     callback();
-                    navigator.pop();
+                    // !IMPORTANT!: You MUST use the BuildContext provided by the dialog when using the navigator, NOT the BuildContext provided by the callback.
+                    // Failure of doing so will result in unintended behavior.
+                    Navigator.pop(context);
                   },
                   child: Text(permConfig.forcedPermissionDialogConfig.buttonText),
                 ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -105,7 +105,7 @@ class App extends StatelessWidget {
           ),
         );
 
-        final result = await perm.show(Navigator.of(context));
+        final result = await perm.show(context);
         if (kDebugMode) {
           print(result);
         }

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -5,8 +5,8 @@ import 'package:flutter_force_permission/flutter_force_permission_config.dart';
 import 'package:flutter_force_permission/permission_required_option.dart';
 import 'package:flutter_force_permission/permission_service_status.dart';
 import 'package:flutter_force_permission/src/flutter_force_permission_util.dart';
+import 'package:flutter_force_permission/src/flutter_force_permission_widget.dart';
 import 'package:flutter_force_permission/src/test_stub.dart';
-import 'package:flutter_force_permission/src/views/disclosure_page.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 /// Flutter Force Permission
@@ -43,9 +43,9 @@ class FlutterForcePermission {
   /// If the disclosure page is already shown, it will do nothing.
   /// Returns a map of Permission and their status after requesting the permissions.
   /// Only permissions specified in the configuration will be included in the return value.
-  Future<Map<Permission, PermissionServiceStatus>> show(
-    NavigatorState navigator,
-  ) async {
+  Future<Map<Permission, PermissionServiceStatus>> show(BuildContext context) async {
+    final navigator = Navigator.of(context);
+
     // Check for permissions.
     final permissionStatuses = await getPermissionStatuses();
     if (_showing) return permissionStatuses;
@@ -67,7 +67,8 @@ class FlutterForcePermission {
     // ignore: avoid-ignoring-return-values, not needed.
     await navigator.push(
       MaterialPageRoute(
-        builder: (context) => DisclosurePage(
+        settings: const RouteSettings(name: '/disclosurePage'),
+        builder: (context) => FlutterForcePermissionWidget(
           permissionConfig: config,
           permissionStatuses: permissionStatuses,
         ),

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -46,7 +46,7 @@ class FlutterForcePermission {
   Future<Map<Permission, PermissionServiceStatus>> show(
     BuildContext context,
   ) async {
-    final navigator = Navigator.of(context);
+    final navigator = _service.getNavigator(context);
 
     // Check for permissions.
     final permissionStatuses = await getPermissionStatuses();

--- a/lib/flutter_force_permission.dart
+++ b/lib/flutter_force_permission.dart
@@ -43,7 +43,9 @@ class FlutterForcePermission {
   /// If the disclosure page is already shown, it will do nothing.
   /// Returns a map of Permission and their status after requesting the permissions.
   /// Only permissions specified in the configuration will be included in the return value.
-  Future<Map<Permission, PermissionServiceStatus>> show(BuildContext context) async {
+  Future<Map<Permission, PermissionServiceStatus>> show(
+    BuildContext context,
+  ) async {
     final navigator = Navigator.of(context);
 
     // Check for permissions.

--- a/lib/src/flutter_force_permission_widget.dart
+++ b/lib/src/flutter_force_permission_widget.dart
@@ -23,15 +23,14 @@ class FlutterForcePermissionWidget extends StatefulWidget {
 
 class _FlutterForcePermissionWidgetState
     extends State<FlutterForcePermissionWidget> {
-
   @override
   Widget build(BuildContext context) => Scaffold(
-      body: Navigator(
-        key: FlutterForcePermissionWidget.navigatorKey,
-        initialRoute: '/disclosurePage',
-        onGenerateRoute: (settings) => _onGenerateRoute(settings, context),
-      ),
-    );
+        body: Navigator(
+          key: FlutterForcePermissionWidget.navigatorKey,
+          initialRoute: '/disclosurePage',
+          onGenerateRoute: (settings) => _onGenerateRoute(settings, context),
+        ),
+      );
 
   Route _onGenerateRoute(RouteSettings settings, BuildContext outerContext) =>
       settings.name == '/disclosurePage'
@@ -51,6 +50,4 @@ class _FlutterForcePermissionWidgetState
               builder: (context) => const Placeholder(),
               settings: settings,
             );
-
-
 }

--- a/lib/src/flutter_force_permission_widget.dart
+++ b/lib/src/flutter_force_permission_widget.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_force_permission/flutter_force_permission_config.dart';
+import 'package:flutter_force_permission/permission_service_status.dart';
+import 'package:flutter_force_permission/src/views/disclosure_page.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class FlutterForcePermissionWidget extends StatefulWidget {
+  const FlutterForcePermissionWidget({
+    required this.permissionConfig,
+    required this.permissionStatuses,
+    super.key,
+  });
+
+  static final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
+
+  final FlutterForcePermissionConfig permissionConfig;
+  final Map<Permission, PermissionServiceStatus> permissionStatuses;
+
+  @override
+  State<FlutterForcePermissionWidget> createState() =>
+      _FlutterForcePermissionWidgetState();
+}
+
+class _FlutterForcePermissionWidgetState
+    extends State<FlutterForcePermissionWidget> {
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+      body: Navigator(
+        key: FlutterForcePermissionWidget.navigatorKey,
+        initialRoute: '/disclosurePage',
+        onGenerateRoute: (settings) => _onGenerateRoute(settings, context),
+      ),
+    );
+
+  Route _onGenerateRoute(RouteSettings settings, BuildContext outerContext) =>
+      settings.name == '/disclosurePage'
+          ? MaterialPageRoute(
+              builder: (context) => DisclosurePage(
+                permissionConfig: widget.permissionConfig,
+                permissionStatuses: widget.permissionStatuses,
+                onDone: () {
+                  // We want to pop the navigator outside the Force Permission widget, popping the entire Force Permission
+                  // and its navigator with it. We use the outer context passed from build to achieve this.
+                  Navigator.pop(outerContext);
+                },
+              ),
+              settings: settings,
+            )
+          : MaterialPageRoute(
+              builder: (context) => const Placeholder(),
+              settings: settings,
+            );
+
+
+}

--- a/lib/src/test_stub.dart
+++ b/lib/src/test_stub.dart
@@ -1,8 +1,9 @@
 import 'package:app_settings/app_settings.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// 3rd party libraries relies on static methods which are unmockable and hence untestable.
+/// 3rd party libraries (and some 1st party ones) relies on static methods which are unmockable and hence untestable.
 /// This service wraps those methods so that it can be tested.
 /// See https://github.com/Baseflow/flutter-permission-handler/issues/262 for details.
 class TestStub {
@@ -22,4 +23,6 @@ class TestStub {
 
   Future<SharedPreferences> getSharedPreference() =>
       SharedPreferences.getInstance();
+
+  NavigatorState getNavigator(BuildContext context) => Navigator.of(context);
 }

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_force_permission/flutter_force_permission.dart';
 import 'package:flutter_force_permission/flutter_force_permission_config.dart';
 import 'package:flutter_force_permission/permission_item_config.dart';
 import 'package:flutter_force_permission/permission_item_text.dart';

--- a/lib/src/views/disclosure_page.dart
+++ b/lib/src/views/disclosure_page.dart
@@ -310,31 +310,10 @@ class _DisclosurePageState extends State<DisclosurePage>
     PermissionItemText permConfig,
     VoidCallback openSettings,
   ) async {
-    final navigator = FlutterForcePermissionWidget.navigatorKey.currentState;
     final dialogConfig = permConfig.forcedPermissionDialogConfig;
     final callback = widget.permissionConfig.showDialogCallback;
 
     if (callback == null) {
-      final actions = <TextButton>[];
-      if (option == PermissionRequiredOption.ask) {
-        actions.add(
-          TextButton(
-            onPressed: navigator?.pop,
-            child:
-                Text(dialogConfig?.cancelText ?? '', textAlign: TextAlign.end),
-          ),
-        );
-      }
-      actions.add(
-        TextButton(
-          onPressed: () {
-            openSettings();
-            navigator?.pop();
-          },
-          child: Text(dialogConfig?.buttonText ?? '', textAlign: TextAlign.end),
-        ),
-      );
-
       // ignore: avoid-ignoring-return-values, not needed.
       await showDialog(
         context: context,
@@ -348,7 +327,30 @@ class _DisclosurePageState extends State<DisclosurePage>
             content: Text(
               dialogConfig?.text ?? '',
             ),
-            actions: actions,
+            actions: <TextButton>[
+              if (option == PermissionRequiredOption.ask)
+                TextButton(
+                  onPressed: () {
+                    // Pop from dialog context, only pop the dialog.
+                    Navigator.pop(context);
+                  },
+                  child: Text(
+                    dialogConfig?.cancelText ?? '',
+                    textAlign: TextAlign.end,
+                  ),
+                ),
+              TextButton(
+                onPressed: () {
+                  openSettings();
+                  // Pop from dialog context, only pop the dialog.
+                  Navigator.pop(context);
+                },
+                child: Text(
+                  dialogConfig?.buttonText ?? '',
+                  textAlign: TextAlign.end,
+                ),
+              ),
+            ],
           ),
         ),
       );

--- a/test/unit_test/flutter_force_permission_test.dart
+++ b/test/unit_test/flutter_force_permission_test.dart
@@ -14,12 +14,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'flutter_force_permission_test.mocks.dart';
 
-@GenerateMocks([NavigatorState, TestStub, SharedPreferences])
+@GenerateMocks([BuildContext, NavigatorState, TestStub, SharedPreferences])
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-
-  final navigator = MockNavigatorState();
-  when(navigator.push(any)).thenAnswer((realInvocation) => Future.value());
 
   test('Show disclosure page', () async {
     await _test();
@@ -59,6 +56,7 @@ Future<void> _test({
   permissionRequired = PermissionRequiredOption.none,
   expectNavigatorPushed = true,
 }) async {
+  final context = MockBuildContext();
   final navigator = MockNavigatorState();
   when(navigator.push(any)).thenAnswer((realInvocation) => Future.value());
 
@@ -73,6 +71,8 @@ Future<void> _test({
       .thenAnswer((realInvocation) => Future.value(serviceStatus));
   when(testStub.getSharedPreference())
       .thenAnswer((realInvocation) => Future.value(prefs));
+  when(testStub.getNavigator(context))
+      .thenAnswer((realInvocation) => navigator);
 
   final config = FlutterForcePermissionConfig(
     title: 'Title',
@@ -97,7 +97,7 @@ Future<void> _test({
   }
 
   final instance = FlutterForcePermission.stub(config, testStub, prefSession);
-  final result = await instance.show(navigator);
+  final result = await instance.show(context);
 
   if (expectNavigatorPushed) {
     verify(navigator.push(any));


### PR DESCRIPTION
#### What does this change?
Use own navigator instead of passed in one. This should help avoid various unintended behaviors or crashes.

#### How do we test this change?

#### Any screenshot for this change?

#### Checklist
- [x] Create suitable unit/widget tests for your change.
- [x] Run the `pre_pr.sh` script to ensure code quality.
